### PR TITLE
adding message type, and making sure message type doesn't get overriden

### DIFF
--- a/lib/braze_plugin.dart
+++ b/lib/braze_plugin.dart
@@ -693,7 +693,7 @@ enum DismissType { swipe, auto_dismiss }
 enum ClickAction { news_feed, uri, none }
 
 /// Braze in-app message types
-enum MessageType { slideup, modal, full, html_full }
+enum MessageType { slideup, modal, full, html_full, html }
 
 class BrazeContentCard {
   /// Content Card json
@@ -981,6 +981,7 @@ class BrazeInAppMessage {
             .toLowerCase()
             .endsWith(messageTypeJson.toLowerCase())) {
           messageType = type;
+          break;
         }
       }
     }


### PR DESCRIPTION
The "html" message type was missing causing "slideup" to get returned.

Also when using the "full" type it would loop thru to the "html_full" and return that since it ends with "full"