### PR TITLE
fix: update com.braze:android-sdk-ui to 30.4.0 to fix braze-inc/braze-android-sdk#28

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,7 +52,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "com.braze:android-sdk-ui:30.3.0"
+    implementation "com.braze:android-sdk-ui:30.4.0"
 
     androidTestImplementation "org.mockito:mockito-android:3.12.4"
     androidTestImplementation "junit:junit:4.13.2"


### PR DESCRIPTION
This PR updates `com.braze:android-sdk-ui` to `v30.4.0` to address https://github.com/braze-inc/braze-android-sdk/issues/28

> Fixed an issue with com.braze.support.DateTimeUtils.nowInMilliseconds() where, in the event of the device network time clock not being available, the SDK would continually log about the error.

NOTE: Until this is fix is merged and released we have to manually update/pin it in `android/app/build.gradle`

```groovy
dependencies {
  implementation "com.braze:android-sdk-ui:30.4.0"
}
```

Fixes #67 