### PR TITLE
feat: add getRegisteredPushToken() to read the device's push token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+##### Added
+- Adds `BrazePlugin.getRegisteredPushToken()`, which returns the push token currently registered for the device with Braze (or `null` if none). Combined with `changeUser` and `registerPushToken`, this lets an app move a device's push token to another profile on logout (e.g. an anonymous user), so a logged-out user no longer receives push addressed to their profile — without affecting the user's other devices.
+
 ## 20.0.0
 
 ##### Breaking

--- a/android/src/main/kotlin/com/braze/brazeplugin/BrazePlugin.kt
+++ b/android/src/main/kotlin/com/braze/brazeplugin/BrazePlugin.kt
@@ -717,6 +717,10 @@ class BrazePlugin : MethodCallHandler, FlutterPlugin, ActivityAware {
                     getBrazeInstance(context).registeredPushToken = pushToken
                 }
 
+                "getRegisteredPushToken" -> {
+                    result.success(getBrazeInstance(context).registeredPushToken)
+                }
+
                 "getDeviceId" -> {
                     result.success(getBrazeInstance(context).deviceId)
                 }

--- a/android/src/test/kotlin/com/braze/brazeplugin/BrazePluginTest.kt
+++ b/android/src/test/kotlin/com/braze/brazeplugin/BrazePluginTest.kt
@@ -1592,6 +1592,21 @@ class BrazePluginTest {
     }
 
     @Test
+    fun whenGetRegisteredPushToken_returnsRegisteredPushToken() {
+        // Given
+        val pushToken = "test_push_token"
+        `when`(mockBraze.registeredPushToken).thenReturn(pushToken)
+        val arguments = emptyMap<String, Any>()
+
+        // When
+        val call = MethodCall("getRegisteredPushToken", arguments)
+        brazePlugin.onMethodCall(call, mockMethodChannelResult)
+
+        // Then
+        verify(mockMethodChannelResult).success(pushToken)
+    }
+
+    @Test
     fun whenGetDeviceId_returnsDeviceId() {
         // Given
         val deviceId = "test_device_id"

--- a/ios/braze_plugin/Sources/braze_plugin/BrazePlugin.swift
+++ b/ios/braze_plugin/Sources/braze_plugin/BrazePlugin.swift
@@ -708,6 +708,15 @@ public class BrazePlugin: NSObject, FlutterPlugin, BrazeSDKAuthDelegate {
         print("Invalid Push Token String (expected hex-encoded string): \(token). Skipping token registration.")
       }
 
+    case "getRegisteredPushToken":
+      // Return the APNs device token as a hex string (symmetric with
+      // `registerPushToken`, which expects hex), or nil if none is registered.
+      if let tokenData = brazeClient?.braze.notifications.deviceToken {
+        result(tokenData.map { String(format: "%02x", $0) }.joined())
+      } else {
+        result(nil)
+      }
+
     case "wipeData":
       brazeClient?.braze.wipeData()
 

--- a/lib/braze_plugin.dart
+++ b/lib/braze_plugin.dart
@@ -625,6 +625,25 @@ class BrazePlugin {
     _callStringMethod('registerPushToken', 'pushToken', pushToken);
   }
 
+  /// Returns the push token currently registered for this device with Braze,
+  /// or `null` if none is registered.
+  ///
+  /// The returned format matches [registerPushToken]: the FCM registration
+  /// token string on Android, and a hexadecimal-encoded string of the APNs
+  /// device token on iOS.
+  ///
+  /// This is useful on logout to move this device's token to a different (e.g.
+  /// anonymous) profile without waiting for the next automatic token
+  /// collection: read the token, [changeUser] to the new profile, then
+  /// [registerPushToken] the same token — Braze removes it from any other user
+  /// previously logged in on this device. This is per-device: the user's other
+  /// devices keep their own tokens.
+  Future<String?> getRegisteredPushToken() {
+    return _channel
+        .invokeMethod('getRegisteredPushToken')
+        .then((value) => value as String?);
+  }
+
   /// Requests an immediate data flush.
   void requestImmediateDataFlush() {
     _channel.invokeMethod('requestImmediateDataFlush');

--- a/test/braze_plugin_test.dart
+++ b/test/braze_plugin_test.dart
@@ -36,6 +36,8 @@ void main() {
           return TestData.mockDeviceId;
         case 'getUserId':
           return TestData.mockUserId;
+        case 'getRegisteredPushToken':
+          return TestData.mockPushToken;
         case 'getAllFeatureFlags':
           return [TestData.featureFlagJson];
         case 'getFeatureFlagByID':
@@ -1298,6 +1300,14 @@ void main() {
           arguments: <String, dynamic>{'pushToken': pushToken},
         ),
       ]);
+    });
+
+    test('should call getRegisteredPushToken', () async {
+      final result = await braze.getRegisteredPushToken();
+      expect(log, <Matcher>[
+        isMethodCall('getRegisteredPushToken', arguments: null)
+      ]);
+      expect(result, TestData.mockPushToken);
     });
 
     test('should call requestImmediateDataFlush', () {

--- a/test/fixtures/test_data.dart
+++ b/test/fixtures/test_data.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 class TestData {
   static const String mockDeviceId = '_test_device_id_';
   static const String mockUserId = '_test_user_id_';
+  static const String mockPushToken = '_test_push_token_';
 
   static const Map<String, dynamic> jsonObject = {
     'jsonobject': {


### PR DESCRIPTION
## Summary

Adds `BrazePlugin.getRegisteredPushToken()`, which returns the push token currently registered for this device with Braze (or `null` if none). The returned format matches `registerPushToken`: the FCM registration token string on Android, and a hex-encoded APNs device token on iOS.

## Motivation

The plugin exposes `registerPushToken(token)` (a setter) but no way to **read** the token the SDK currently holds. That gap makes a common logout requirement hard to satisfy: moving a device's push token off the departing user's profile so a **logged-out user stops receiving push addressed to their profile**, without affecting that user's other devices.

`changeUser` alone does not move an already-registered token (the token only re-associates when it is next registered/collected), and clearing it by registering `null` is rejected by the native SDKs. The reliable, documented path is to **re-register the same token under the new user** — but that requires reading the token first, which isn't currently possible from Dart.

With this getter, an app can, on logout:

```dart
final token = await braze.getRegisteredPushToken();
braze.changeUser(anonymousId);
if (token != null && token.isNotEmpty) braze.registerPushToken(token);
```

Braze then removes the token from the user previously logged in on that device — per-device, so the user's other devices keep their own tokens.

## Changes

- **Dart**: `Future<String?> getRegisteredPushToken()`
- **Android**: returns `Braze.registeredPushToken`
- **iOS**: returns `braze.notifications.deviceToken` as a hex string (symmetric with `registerPushToken`'s hex input)
- **Tests**: `BrazePluginTest` (Android) + `braze_plugin_test` (Dart), plus a CHANGELOG entry

## Testing

- Dart unit tests pass (`flutter test`); added `getRegisteredPushToken` coverage on Dart and Android.
- Verified **end-to-end in a downstream app** on a real Android device and a real iOS device: on logout, reading the token + `changeUser(anon)` + re-`registerPushToken` moves the device's token off the previous user's profile server-side (confirmed in the Braze dashboard "Push token was moved to another user").

## Notes

- The iOS getter (`braze.notifications.deviceToken`) is available in current Braze Swift SDK versions; this change was validated against 14.1.0 and 16.0.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only API over existing SDK token state; logout re-registration is an app-driven pattern with tests but limited blast radius in the plugin itself.
> 
> **Overview**
> Adds **`BrazePlugin.getRegisteredPushToken()`**, a read path for the push token Braze already holds on the device (`null` when none). Return formats mirror **`registerPushToken`**: FCM string on Android, hex APNs on iOS.
> 
> Native bridges wire **`getRegisteredPushToken`** on Android (`Braze.registeredPushToken`) and iOS (`notifications.deviceToken` encoded to hex). Dart unit tests, an Android plugin test, and an **Unreleased** CHANGELOG entry cover the API.
> 
> The main use case is **logout**: fetch the token, **`changeUser`** to an anonymous (or other) profile, then **`registerPushToken`** again so this device stops receiving push for the prior user without waiting for the next token refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07f437f66841f78b50f7b484a8d28d260ba2a759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->