### PR TITLE
Release Flutter SDK version 21.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 21.0.0
+
+##### Breaking
+- Updates the native iOS bridge [from Braze Swift SDK 16.0.0 to 17.0.0](https://github.com/braze-inc/braze-swift-sdk/compare/16.0.0...17.0.0#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed).
+  - With this update, the native `Braze.init` and `changeUser(userId:)` no longer block the calling thread. Refer to the full release notes for Swift SDK 17.0.0 for more details.
+- Removes the following deprecated methods:
+  - `logCustomEventWithProperties()`. Use `logCustomEvent()` instead.
+  - `logPurchaseWithProperties()`. Use `logPurchase()` instead.
+  - `registerAndroidPushToken()`. Use `registerPushToken()` instead.
+  - `getInstallTrackingId()`. Use `getDeviceId()` instead.
+  - `setGoogleAdvertisingId()`. Use `setAdTrackingEnabled()` instead.
+
+##### Fixed
+- Fixes an iOS race where a Braze method called immediately after `initialize()` was silently dropped because the native Braze instance had not been created yet. The instance is now created synchronously so calls made right after `initialize()` are applied to a valid instance.
+- The native `changeUser`, `enableSDK`, and `disableSDK` handlers now return a completion result on both iOS and Android, so awaiting these method channel calls no longer hangs.
+
 ## 20.0.0
 
 ##### Breaking

--- a/android/src/main/kotlin/com/braze/brazeplugin/BrazePlugin.kt
+++ b/android/src/main/kotlin/com/braze/brazeplugin/BrazePlugin.kt
@@ -208,6 +208,7 @@ class BrazePlugin : MethodCallHandler, FlutterPlugin, ActivityAware {
                     } else {
                         getBrazeInstance(context).changeUser(userId, sdkAuthSignature)
                     }
+                    result.success(null)
                 }
 
                 "getUserId" -> {
@@ -763,10 +764,12 @@ class BrazePlugin : MethodCallHandler, FlutterPlugin, ActivityAware {
 
                 "enableSDK" -> {
                     Braze.enableSdk(context)
+                    result.success(null)
                 }
 
                 "disableSDK" -> {
                     Braze.disableSdk(context)
+                    result.success(null)
                 }
 
                 /**

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -20,7 +20,7 @@ plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0" // apply true
     id "com.android.application" version "8.13.2" apply false
     id "org.jetbrains.kotlin.android" version "2.1.20" apply false
-    id "com.github.burrunan.s3-build-cache" version "1.9.6"
+    id "com.github.burrunan.s3-build-cache" version "1.9.7"
 }
 
 buildCache {

--- a/example/integration_test/braze_plugin_integration_test.dart
+++ b/example/integration_test/braze_plugin_integration_test.dart
@@ -1,5 +1,8 @@
+import 'dart:io' show Platform;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:braze_plugin/braze_plugin.dart';
+import 'package:braze_plugin_example/constants/config.dart';
 import 'package:integration_test/integration_test.dart';
 
 void main() {
@@ -10,5 +13,20 @@ void main() {
     Future<String> getDeviceId = plugin.getDeviceId();
     expect(plugin, isNotNull);
     expect(getDeviceId, isNotNull);
+  });
+
+  testWidgets(
+      'Synchronous method calls succeed immediately after initialize call',
+      (WidgetTester tester) async {
+    final plugin = BrazePlugin(customConfigs: {replayCallbacksConfigKey: true});
+    final apiKey = Platform.isIOS ? defaultIOSApiKey : defaultAndroidApiKey;
+
+    plugin.initialize(apiKey, defaultEndpoint);
+
+    const testUserId = 'test-user';
+    plugin.changeUser(testUserId);
+
+    final userId = await plugin.getUserId();
+    expect(userId, testUserId);
   });
 }

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -1000,7 +1000,7 @@
 			repositoryURL = "https://github.com/braze-inc/braze-swift-sdk";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 16.0.0;
+				minimumVersion = 17.0.0;
 			};
 		};
 		D54250692F325F1200919601 /* XCRemoteSwiftPackageReference "SDWebImage" */ = {

--- a/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SDWebImage/SDWebImage",
       "state" : {
-        "revision" : "449e8f8f10377f620db8ad22ea81208eecf6325f",
-        "version" : "5.21.6"
+        "revision" : "2de3a496eaf6df9a1312862adcfd54acd73c39c0",
+        "version" : "5.21.7"
       }
     }
   ],

--- a/example/lib/screens/user_management_screen.dart
+++ b/example/lib/screens/user_management_screen.dart
@@ -551,33 +551,6 @@ class _UserManagementScreenState extends State<UserManagementScreen> {
                     context.showBrazeAppSnackbar('Attribution data set');
                   },
                 ),
-                BrazeAppButton(
-                  title: 'Get Install Tracking ID (deprecated)',
-                  variant: BrazeButtonVariant.secondary,
-                  onPressed: () {
-                    if (!validateBrazeSdkEnabled(context)) return;
-                    // ignore: deprecated_member_use
-                    braze.getInstallTrackingId().then((result) {
-                      if (!mounted) return;
-                      context.showBrazeAppSnackbar(
-                        'Install Tracking ID: $result',
-                      );
-                    });
-                  },
-                ),
-                if (Platform.isAndroid)
-                  BrazeAppButton(
-                    title: 'Set Google Advertising ID (deprecated)',
-                    variant: BrazeButtonVariant.secondary,
-                    onPressed: () {
-                      if (!validateBrazeSdkEnabled(context)) return;
-                      // ignore: deprecated_member_use
-                      braze.setGoogleAdvertisingId('dummy-id', false);
-                      context.showBrazeAppSnackbar(
-                        'Set Google Advertising ID',
-                      );
-                    },
-                  ),
               ],
             ),
             BrazeAppCard(

--- a/ios/braze_plugin.podspec
+++ b/ios/braze_plugin.podspec
@@ -7,7 +7,7 @@ require 'yaml'
 pubspec = YAML.load_file(File.join(__dir__, '../pubspec.yaml'))
 flutter_version = pubspec['version']
 
-braze_swift_version = '16.0.0'
+braze_swift_version = '17.0.0'
 
 Pod::Spec.new do |s|
   s.name             = 'braze_plugin'

--- a/ios/braze_plugin/Package.swift
+++ b/ios/braze_plugin/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/braze-inc/braze-swift-sdk",
-            from: "16.0.0"
+            from: "17.0.0"
         )
     ],
     targets: [

--- a/ios/braze_plugin/Sources/braze_plugin/BrazePlugin.swift
+++ b/ios/braze_plugin/Sources/braze_plugin/BrazePlugin.swift
@@ -69,6 +69,7 @@ public class BrazePlugin: NSObject, FlutterPlugin, BrazeSDKAuthDelegate {
     channels.append(channel)
   }
 
+  @MainActor
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     let argsDescription = String(describing: call.arguments)
 
@@ -101,29 +102,30 @@ public class BrazePlugin: NSObject, FlutterPlugin, BrazeSDKAuthDelegate {
       }
       let configuration = Braze.Configuration(apiKey: apiKey, endpoint: endpoint)
       BrazePlugin.configure?(configuration)
-      DispatchQueue.main.async {
-        let braze = BrazePlugin.createBrazeInstance(configuration)
-        BrazePlugin.postInitialization?(braze)
-        result(nil)
-      }
+      let braze = BrazePlugin.createBrazeInstance(configuration)
+      BrazePlugin.postInitialization?(braze)
+      result(nil)
 
     case "changeUser":
       guard let args = call.arguments as? [String: Any],
         let userId = args["userId"] as? String
       else {
         print("Invalid args: \(argsDescription), iOS method: \(call.method)")
+        result(nil)
         return
       }
       if Array(args.keys).contains("sdkAuthSignature") {
         guard let sdkAuthSignature = args["sdkAuthSignature"] as? String
         else {
           print("Invalid args: \(argsDescription), iOS method: \(call.method)")
+          result(nil)
           return
         }
         brazeClient?.braze.changeUser(userId: userId, sdkAuthSignature: sdkAuthSignature)
       } else {
         brazeClient?.braze.changeUser(userId: userId)
       }
+      result(nil)
 
     case "getUserId":
       result(brazeClient?.braze.user.id)
@@ -744,8 +746,10 @@ public class BrazePlugin: NSObject, FlutterPlugin, BrazeSDKAuthDelegate {
 
     case "enableSDK":
       brazeClient?.braze.enabled = true
+      result(nil)
     case "disableSDK":
       brazeClient?.braze.enabled = false
+      result(nil)
 
     case "getFeatureFlagByID":
       guard let args = call.arguments as? [String: Any],
@@ -1047,6 +1051,14 @@ public class BrazePlugin: NSObject, FlutterPlugin, BrazeSDKAuthDelegate {
   @MainActor
   @discardableResult
   private class func createBrazeInstance(_ configuration: Braze.Configuration) -> Braze {
+    // BrazeKit requires that the `Braze` instance be created on the main thread.
+    // Certain features fail at runtime otherwise.
+    // The `@MainActor` chain guarantees this at compile time, but that isolation
+    // is not enforced at the `@objc` FlutterMethodChannel boundary.
+    if !Thread.isMainThread {
+      print("[BrazePlugin] createBrazeInstance called off the iOS main thread. Braze features may fail.")
+    }
+
     // Cancel previous subscriptions to prevent potential reference cycle.
     brazeSubscriptionManager?.cancelAllSubscriptions()
 
@@ -1094,7 +1106,8 @@ public class BrazePlugin: NSObject, FlutterPlugin, BrazeSDKAuthDelegate {
 
   /// Translates the native [inAppMessage] into JSON and passes it from the iOS layer
   /// to the Dart layer.
-  /// Note: Swift closures are unable to be translated into JSON.
+  ///
+  /// - Note: Swift closures are unable to be translated into JSON.
   ///
   /// - Parameter inAppMessage: The Braze in-app message in native Swift.
   public class func processInAppMessage(_ inAppMessage: Braze.InAppMessage) {
@@ -1113,7 +1126,8 @@ public class BrazePlugin: NSObject, FlutterPlugin, BrazeSDKAuthDelegate {
 
   /// Translates each of the the native content [cards] into JSON and passes it
   /// from the iOS layer to the Dart layer.
-  /// Note: Swift closures are unable to be translated into JSON.
+  ///
+  /// - Note: Swift closures are unable to be translated into JSON.
   ///
   /// - Parameter cards: The array of Braze content cards in native Swift.
   public class func processContentCards(_ cards: [Braze.ContentCard]) {
@@ -1136,7 +1150,8 @@ public class BrazePlugin: NSObject, FlutterPlugin, BrazeSDKAuthDelegate {
 
   /// Translates each of the native banner [banners] into JSON and passes it
   /// from the iOS layer to the Dart layer.
-  /// Note: Swift closures are unable to be translated into JSON.
+  ///
+  /// - Note: Swift closures are unable to be translated into JSON.
   ///
   /// - Parameter banners: The dictionary of Braze banners in native Swift.
   public class func processBanners(_ banners: [String: Braze.Banner]) {
@@ -1200,7 +1215,8 @@ public class BrazePlugin: NSObject, FlutterPlugin, BrazeSDKAuthDelegate {
 
   /// Translates each of the native [featureFlags] into JSON and passes it
   /// from the iOS layer to the Dart layer.
-  /// Note: Swift closures are unable to be translated into JSON.
+  ///
+  /// - Note: Swift closures are unable to be translated into JSON.
   ///
   /// - Parameter featureFlags: The array of Braze feature flags in native Swift.
   public class func processFeatureFlags(_ featureFlags: [Braze.FeatureFlag]) {

--- a/lib/braze_plugin.dart
+++ b/lib/braze_plugin.dart
@@ -3,7 +3,6 @@ library braze_plugin;
 import 'dart:async';
 import 'dart:convert' as json;
 import 'dart:developer';
-import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -373,17 +372,6 @@ class BrazePlugin {
     _channel.invokeMethod('logCustomEvent', params);
   }
 
-  /// Logs a custom event to Braze.
-  @Deprecated('Use logCustomEvent(eventName, properties: properties) instead.')
-  void logCustomEventWithProperties(
-      String eventName, Map<String, dynamic> properties) {
-    final Map<String, dynamic> params = <String, dynamic>{
-      "eventName": eventName,
-      "properties": properties
-    };
-    _channel.invokeMethod('logCustomEvent', params);
-  }
-
   /// Logs a purchase event to Braze.
   void logPurchase(
       String productId, String currencyCode, double price, int quantity,
@@ -398,21 +386,6 @@ class BrazePlugin {
       // Omits entry when properties is null
       params["properties"] = properties;
     }
-    _channel.invokeMethod('logPurchase', params);
-  }
-
-  /// Logs a purchase event to Braze.
-  @Deprecated(
-      'Use logPurchase(productId, currencyCode, price, quantity, properties: properties) instead.')
-  void logPurchaseWithProperties(String productId, String currencyCode,
-      double price, int quantity, Map<String, dynamic> properties) {
-    final Map<String, dynamic> params = <String, dynamic>{
-      "productId": productId,
-      "currencyCode": currencyCode,
-      "price": price,
-      "quantity": quantity,
-      "properties": properties
-    };
     _channel.invokeMethod('logPurchase', params);
   }
 
@@ -600,16 +573,6 @@ class BrazePlugin {
     _channel.invokeMethod('setAttributionData', params);
   }
 
-  /// Registers a push token for the current Android device with Braze.
-  /// - No-op on iOS.
-  /// This method is deprecated in favor of `registerPushToken`, which supports iOS and Android.
-  @Deprecated('Use registerPushToken(pushToken) instead.')
-  void registerAndroidPushToken(String pushToken) {
-    if (Platform.isAndroid) {
-      registerPushToken(pushToken);
-    }
-  }
-
   /// Registers a push token for the current device with Braze.
   ///
   /// Only use this method if you are not already registering for push notifications in the
@@ -719,25 +682,6 @@ class BrazePlugin {
     return _channel
         .invokeMethod('getDeviceId')
         .then<String>((dynamic result) => result);
-  }
-
-  /// Gets the install tracking id.
-  @Deprecated('Use getDeviceId instead.')
-  Future<String> getInstallTrackingId() {
-    return _channel
-        .invokeMethod('getDeviceId')
-        .then<String>((dynamic result) => result);
-  }
-
-  /// Sets Google Advertising Id for the current user.
-  /// - No-op on iOS.
-  @Deprecated('Use setAdTrackingEnabled(adTrackingEnabled, id) instead.')
-  void setGoogleAdvertisingId(String id, bool adTrackingEnabled) {
-    final Map<String, dynamic> params = <String, dynamic>{
-      "id": id,
-      "adTrackingEnabled": adTrackingEnabled
-    };
-    _channel.invokeMethod('setGoogleAdvertisingId', params);
   }
 
   /// Sets ad tracking configuration for the current user.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: braze_plugin
 description: This is the Braze plugin for Flutter. Effective marketing automation is an essential part of successfully scaling and managing your business.
-version: 20.0.0
+version: 21.0.0
 homepage: https://www.braze.com/
 repository: https://github.com/braze-inc/braze-flutter-sdk
 

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -1,7 +1,7 @@
 echo "-> Running braze_plugin unit tests..."
 flutter test test/braze_plugin_test.dart -r expanded
 
-echo "\n-> Running Android integration tests..."
+echo "\n-> Running integration tests..."
 cd example
 flutter drive \
   --driver=test_driver/integration_test.dart \

--- a/test/braze_plugin_test.dart
+++ b/test/braze_plugin_test.dart
@@ -1,5 +1,4 @@
 import 'dart:convert' as json;
-import 'dart:io' show Platform;
 
 import 'package:braze_plugin/braze_plugin.dart';
 import 'package:flutter/services.dart';
@@ -32,7 +31,6 @@ void main() {
       log.add(methodCall);
       switch (methodCall.method) {
         case 'getDeviceId':
-        case 'getInstallTrackingId':
           return TestData.mockDeviceId;
         case 'getUserId':
           return TestData.mockUserId;
@@ -183,22 +181,6 @@ void main() {
       ]);
     });
 
-    test('should call logCustomEventWithProperties', () {
-      const eventName = 'someEvent';
-      final properties = {'someKey': 'someValue'};
-      // ignore: deprecated_member_use_from_same_package
-      braze.logCustomEventWithProperties(eventName, properties);
-      expect(log, <Matcher>[
-        isMethodCall(
-          'logCustomEvent',
-          arguments: <String, dynamic>{
-            'eventName': eventName,
-            'properties': properties
-          },
-        ),
-      ]);
-    });
-
     test('should call logPurchase with no properties', () {
       const productId = 'someProduct';
       const currencyCode = 'someCurrencyCode';
@@ -267,29 +249,6 @@ void main() {
             'price': price,
             'quantity': quantity,
             'properties': properties,
-          },
-        ),
-      ]);
-    });
-
-    test('should call logPurchaseWithProperties', () {
-      const productId = 'someProduct';
-      const currencyCode = 'someCurrencyCode';
-      const price = 4.2;
-      const quantity = 42;
-      final properties = {'someKey': 'someValue'};
-      // ignore: deprecated_member_use_from_same_package
-      braze.logPurchaseWithProperties(
-          productId, currencyCode, price, quantity, properties);
-      expect(log, <Matcher>[
-        isMethodCall(
-          'logPurchase',
-          arguments: <String, dynamic>{
-            'productId': productId,
-            'currencyCode': currencyCode,
-            'price': price,
-            'quantity': quantity,
-            'properties': properties
           },
         ),
       ]);
@@ -1263,31 +1222,6 @@ void main() {
       expect(result, TestData.mockDeviceId);
     });
 
-    test('should call getInstallTrackingId', () async {
-      // ignore: deprecated_member_use_from_same_package
-      final result = await braze.getInstallTrackingId();
-      expect(log, <Matcher>[
-        isMethodCall('getDeviceId', arguments: null)
-      ]);
-      expect(result, TestData.mockDeviceId);
-    });
-
-    test('should call registerAndroidPushToken', () {
-      const pushToken = 'someToken';
-      // ignore: deprecated_member_use_from_same_package
-      braze.registerAndroidPushToken(pushToken);
-      if (Platform.isAndroid) {
-        expect(log, <Matcher>[
-          isMethodCall(
-            'registerPushToken',
-            arguments: <String, dynamic>{'pushToken': pushToken},
-          ),
-        ]);
-      } else {
-        expect(log, isEmpty);
-      }
-    });
-
     test('should call registerPushToken with a hex string', () {
       const pushToken =
           '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f';
@@ -1304,20 +1238,6 @@ void main() {
       braze.requestImmediateDataFlush();
       expect(log, <Matcher>[
         isMethodCall('requestImmediateDataFlush', arguments: null),
-      ]);
-    });
-
-    test('should call setGoogleAdvertisingId', () {
-      // ignore: deprecated_member_use_from_same_package
-      braze.setGoogleAdvertisingId('some_id', false);
-      expect(log, <Matcher>[
-        isMethodCall(
-          'setGoogleAdvertisingId',
-          arguments: <String, dynamic>{
-            'id': 'some_id',
-            'adTrackingEnabled': false
-          },
-        ),
       ]);
     });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Major semver with breaking Dart API removals and a native iOS SDK upgrade; synchronous main-thread Braze init changes timing for apps that relied on the old async behavior.
> 
> **Overview**
> **21.0.0** bumps the plugin and pins the native iOS bridge to **Braze Swift SDK 17.0.0** (podspec, SPM, example Xcode pins).
> 
> **Breaking:** Removes deprecated Dart APIs (`logCustomEventWithProperties`, `logPurchaseWithProperties`, `registerAndroidPushToken`, `getInstallTrackingId`, `setGoogleAdvertisingId`); callers should use the existing replacement methods documented in the changelog.
> 
> **iOS:** `initialize` now creates the Braze instance **synchronously** on the main actor instead of deferring via `DispatchQueue.main.async`, fixing calls right after `initialize()` being dropped. `changeUser` invalid-arg paths now complete the method channel with `result(nil)`. **`changeUser`**, **`enableSDK`**, and **`disableSDK`** always call `result(nil)` so awaited channel calls do not hang.
> 
> **Android:** Same **`result.success(null)`** completions for **`changeUser`**, **`enableSDK`**, and **`disableSDK`**.
> 
> Adds an integration test that **`changeUser`** immediately after **`initialize`** returns the expected user id; drops sample-app buttons for removed deprecated APIs; minor example Gradle S3 cache plugin bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6bec5b0c2cb0d59c18f098528127288c945e737. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->